### PR TITLE
use lodash's 'isPlainObject' instead of 'isObject'

### DIFF
--- a/src/checkConfig/reformatResult/index.js
+++ b/src/checkConfig/reformatResult/index.js
@@ -1,4 +1,4 @@
-import {isString, isObject} from 'lodash'
+import {isString, isPlainObject} from 'lodash'
 
 export default reformatResult
 
@@ -6,7 +6,7 @@ function reformatResult(result, {description, key} = {}) {
   /* eslint complexity:[2, 6] */
   if (isString(result)) {
     return {type: 'error', message: result}
-  } else if (isObject(result)) {
+  } else if (isPlainObject(result)) {
     if (result.error) {
       return {type: 'error', message: result.error}
     } else if (result.warning) {


### PR DESCRIPTION
Hey, @kentcdodds.
I noticed you're using `isObject` in the codebase and thought that this PR would be a good suggestion:

These changes will guarantee that `reformatResult` will only take in strings and plain javascript objects. And not some other javascript objects such as null, arrays and functions.

From the docs:
https://lodash.com/docs#isObject -> Checks if value is the language type of Object. (e.g. arrays, functions, objects, regexes, new Number(0), and new String(''))

https://lodash.com/docs#isPlainObject -> Checks if value is a plain object, that is, an object created by the Object constructor or one with a [[Prototype]] of null.
