### PR TITLE
chore: update npm deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,12 +12,13 @@
     ]
   },
   "scripts": {
+    "precommit": "npm-run-all --parallel lint cover build",
     "prebuild": "rimraf dist",
     "build": "babel -d dist src",
     "cover": "nyc --reporter=lcov --reporter=text --reporter=html npm run test",
     "check-coverage": "nyc check-coverage --statements 100 --branches 100 --functions 100 --lines 100",
     "lint": "eslint .",
-    "test": "ava 'src/**/*.test.js' --require babel-register",
+    "test": "ava \"src/**/*.test.js\" --require babel-register",
     "watch:test": "nodemon --quiet --watch src --exec npm run test -s",
     "watch:cover": "nodemon --quiet --watch src --exec npm run cover -s",
     "validate": "npm-run-all --parallel lint cover build --sequential check-coverage",
@@ -41,21 +42,21 @@
     "lodash": "^4.3.0"
   },
   "devDependencies": {
-    "ava": "0.11.0",
-    "babel-cli": "6.5.1",
-    "babel-core": "6.5.2",
-    "babel-preset-es2015": "6.5.0",
+    "ava": "0.13.0",
+    "babel-cli": "6.6.5",
+    "babel-core": "6.7.2",
+    "babel-preset-es2015": "6.6.0",
     "babel-preset-stage-2": "6.5.0",
-    "babel-register": "6.5.2",
-    "eslint": "1.10.3",
-    "eslint-config-kentcdodds": "5.1.0",
+    "babel-register": "6.7.2",
+    "eslint": "2.4.0",
+    "eslint-config-kentcdodds": "6.0.0",
     "ghooks": "1.0.3",
-    "nodemon": "1.8.1",
-    "npm-run-all": "1.5.1",
-    "nyc": "5.6.0",
+    "nodemon": "1.9.1",
+    "npm-run-all": "1.5.3",
+    "nyc": "6.1.1",
     "rimraf": "2.5.2",
     "sinon": "1.17.3",
-    "validate-commit-msg": "2.0.0",
+    "validate-commit-msg": "2.4.0",
     "with-package": "0.2.0"
   },
   "eslintConfig": {
@@ -70,7 +71,7 @@
   "config": {
     "ghooks": {
       "commit-msg": "validate-commit-msg",
-      "pre-commit": "npm run validate -s"
+      "pre-commit": "npm run precommit"
     }
   }
 }

--- a/src/checkConfig/index.test.js
+++ b/src/checkConfig/index.test.js
@@ -47,7 +47,7 @@ test('can warn', t => {
   }))
 })
 
-test(`doesn't check non-existing keys`, t => {
+test('doesnot check non-existing keys', t => {
   const validators = [
     getPassingValidator({key: 'foo'}),
     getFailingValidator({key: 'bar'}),
@@ -57,7 +57,7 @@ test(`doesn't check non-existing keys`, t => {
   noErrors(t, result)
 })
 
-test(`doesn't check non-exsisting validators`, t => {
+test('doesnot check non-exsisting validators', t => {
   const validators = [
     getFailingValidator({key: 'baz'}),
   ]

--- a/src/uncoveredPaths/getAllPaths/index.test.js
+++ b/src/uncoveredPaths/getAllPaths/index.test.js
@@ -92,7 +92,7 @@ test('handles recursive structures without blowing up', t => {
 /*
  * Tests below here are used to fix bugs (and keep them from coming back)
  */
-test(`objects with keys who's values are the same as other keys`, t => {
+test('objects with keys who\'s values are the same as other keys', t => {
   const input = {
     externals: {
       angular: 'angular',


### PR DESCRIPTION
This PR updates all the npm dependencies. As npm-run-all fixed the bug according to blanks in paths configuration-validator can now also be developed by Win users.
I also changed the precommit hook to a new script called precommit. This was done because npm run check-coverage fails (Have to invastigate further...). With this change Win users don't need the --no-verify flag when commiting and the checks happen. I think this is better than no commit hook at all because it is more important to have linting & the tests run than to verify coverage.
