### PR TITLE
feat(validateReducer): Add validateReducer utility function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,9 +3,11 @@ import configValidator from './configValidator'
 import checkConfig from './checkConfig'
 import messageFormatter from './messageFormatter'
 import uncoveredPaths from './uncoveredPaths'
+import validateReducer from './validateReducer'
 
 module.exports = configValidator
 module.exports.checkConfig = checkConfig
 module.exports.messageFormatter = messageFormatter
 module.exports.uncoveredPaths = uncoveredPaths
+module.exports.validateReducer = validateReducer
 

--- a/src/validate-reducer/index.js
+++ b/src/validate-reducer/index.js
@@ -1,0 +1,23 @@
+export {validateReducer}
+
+const EXIT_EARLY = 'EXIT_EARLY'
+const CONTINUE = 'CONTINUE'
+
+validateReducer.EXIT_EARLY = EXIT_EARLY
+validateReducer.CONTINUE = CONTINUE
+
+function validateReducer(validators, val, config) {
+  const result = validators.reduce((res, validator) => {
+    if (res !== CONTINUE) {
+      return res
+    }
+    return validator(val, config)
+  }, CONTINUE)
+
+  if (result !== CONTINUE && result !== EXIT_EARLY) {
+    return result
+  } else {
+    return undefined
+  }
+}
+

--- a/src/validate-reducer/index.test.js
+++ b/src/validate-reducer/index.test.js
@@ -1,0 +1,69 @@
+import test from 'ava'
+import {spy} from 'sinon'
+
+import {validateReducer} from './'
+const {EXIT_EARLY, CONTINUE} = validateReducer
+
+test('returns the message of the first message returning validator', t => {
+  const warning = {warning: 'WATCH OUT!'}
+
+  const v1 = spy(() => CONTINUE)
+  const v2 = spy(() => warning)
+  const v3 = spy(() => CONTINUE)
+  const result = validateReducer([v1, v2, v3])
+  t.same(result, warning)
+  t.true(v1.calledOnce)
+  t.true(v2.calledOnce)
+  t.false(v3.called)
+})
+
+test('calls all validators if they all return continue', t => {
+  const v1 = spy(() => CONTINUE)
+  const v2 = spy(() => CONTINUE)
+  const v3 = spy(() => CONTINUE)
+  const result = validateReducer([v1, v2, v3])
+  t.same(result, undefined)
+  t.true(v1.calledOnce)
+  t.true(v2.calledOnce)
+  t.true(v3.calledOnce)
+})
+
+test('stops calling validators when the first validator that returns EXIT_EARLY is called', t => {
+  const v1 = spy(() => CONTINUE)
+  const v2 = spy(() => EXIT_EARLY)
+  const v3 = spy(() => CONTINUE)
+  const result = validateReducer([v1, v2, v3])
+  t.same(result, undefined)
+  t.true(v1.calledOnce)
+  t.true(v2.calledOnce)
+  t.false(v3.called)
+})
+
+test('stops calling validators when the first validator that returns a string is called', t => {
+  const interestingFact = 'The tallest artificial structure is the 829.8 m (2,722 ft) tall Burj Khalifa in Dubai, United Arab Emirates' // eslint-disable-line max-len
+
+  const v1 = spy(() => CONTINUE)
+  const v2 = spy(() => interestingFact)
+  const v3 = spy(() => CONTINUE)
+  const result = validateReducer([v1, v2, v3])
+  t.same(result, interestingFact)
+  t.true(v1.calledOnce)
+  t.true(v2.calledOnce)
+  t.false(v3.called)
+})
+
+/*
+ * This test is basically to tell you that returning `undefined` is just like returning
+ * EXIT_EARLY, except it's less explicit which is not cool 👎
+ */
+test('stops calling validators when the first validator that returns nothing is called', t => {
+  const v1 = spy(() => CONTINUE)
+  const v2 = spy(() => undefined)
+  const v3 = spy(() => CONTINUE)
+  const result = validateReducer([v1, v2, v3])
+  t.same(result, undefined)
+  t.true(v1.calledOnce)
+  t.true(v2.calledOnce)
+  t.false(v3.called)
+})
+


### PR DESCRIPTION
This pulls the `validateReducer` function which I developed [here](https://github.com/kentcdodds/webpack-validator/blob/65111bb9c80fd5e9771ad9ec14bf02dd116275c5/src/validators/stats/index.js#L24-L33) out into the `configurationValidator` because this could be a really handy function for validators.

@xjamundx, @nyrosmith, @sarbbottam, @jonathanewerner. Just looking for one reviewer to merge this one I think :-)
